### PR TITLE
Stop building static libs

### DIFF
--- a/clm/CMakeLists.txt
+++ b/clm/CMakeLists.txt
@@ -1,5 +1,11 @@
 list(APPEND CLM_CLM_SOURCES
     src/clm_compiler.c
+
+    $<TARGET_OBJECTS:clmUtil>
+    $<TARGET_OBJECTS:clmLexer>
+    $<TARGET_OBJECTS:clmParser>
+    $<TARGET_OBJECTS:clmSymbolGen>
+    $<TARGET_OBJECTS:clmTypeCheck>
 )
 
 add_executable(clm ${CLM_CLM_SOURCES})
@@ -9,11 +15,4 @@ target_include_directories(clm
     PUBLIC ${CLM_SOURCE_DIR}/parser/include
     PUBLIC ${CLM_SOURCE_DIR}/symbolGen/include
     PUBLIC ${CLM_SOURCE_DIR}/typeCheck/include
-)
-target_link_libraries(clm
-    clmUtil
-    clmLexer
-    clmParser
-    clmSymbolGen
-    clmTypeCheck
 )

--- a/lexer/CMakeLists.txt
+++ b/lexer/CMakeLists.txt
@@ -2,11 +2,8 @@ list(APPEND CLM_LEXER_SOURCES
     src/clm_lexer.c
 )
 
-add_library(clmLexer STATIC ${CLM_LEXER_SOURCES})
+add_library(clmLexer OBJECT ${CLM_LEXER_SOURCES})
 target_include_directories(clmLexer
     PUBLIC include
     PUBLIC ${CLM_SOURCE_DIR}/util/include
-)
-target_link_libraries(clmLexer
-    clmUtil
 )

--- a/parser/CMakeLists.txt
+++ b/parser/CMakeLists.txt
@@ -2,13 +2,9 @@ list(APPEND CLM_PARSER_SOURCES
     src/clm_parser.c
 )
 
-add_library(clmParser STATIC ${CLM_PARSER_SOURCES})
+add_library(clmParser OBJECT ${CLM_PARSER_SOURCES})
 target_include_directories(clmParser
     PUBLIC include
     PUBLIC ${CLM_SOURCE_DIR}/util/include
     PUBLIC ${CLM_SOURCE_DIR}/lexer/include
-)
-target_link_libraries(clmParser
-    clmUtil
-    clmLexer
 )

--- a/symbolGen/CMakeLists.txt
+++ b/symbolGen/CMakeLists.txt
@@ -2,11 +2,8 @@ list(APPEND CLM_SYMBOL_GEN_SOURCES
     src/clm_symbol_gen.c
 )
 
-add_library(clmSymbolGen STATIC ${CLM_SYMBOL_GEN_SOURCES})
+add_library(clmSymbolGen OBJECT ${CLM_SYMBOL_GEN_SOURCES})
 target_include_directories(clmSymbolGen
     PUBLIC include
     PUBLIC ${CLM_SOURCE_DIR}/util/include
-)
-target_link_libraries(clmSymbolGen
-    clmUtil
 )

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,6 +1,9 @@
 list(APPEND CLM_TESTS_SOURCES
     src/clm_test_main.c
     src/clm_test_lexer.c
+
+    $<TARGET_OBJECTS:clmUtil>
+    $<TARGET_OBJECTS:clmLexer>
 )
 
 if(${CLM_BUILD_TESTS})
@@ -9,10 +12,6 @@ add_executable(clm_tests ${CLM_TESTS_SOURCES})
 target_include_directories(clm_tests
     PUBLIC include
     PUBLIC ${CLM_SOURCE_DIR}/lexer/include
-)
-target_link_libraries(clm_tests
-    clmUtil
-    clmLexer
 )
 
 endif()

--- a/typeCheck/CMakeLists.txt
+++ b/typeCheck/CMakeLists.txt
@@ -2,11 +2,8 @@ list(APPEND CLM_TYPE_CHECK_SOURCES
     src/clm_type_check.c
 )
 
-add_library(clmTypeCheck STATIC ${CLM_TYPE_CHECK_SOURCES})
+add_library(clmTypeCheck OBJECT ${CLM_TYPE_CHECK_SOURCES})
 target_include_directories(clmTypeCheck
     PUBLIC include
     PUBLIC ${CLM_SOURCE_DIR}/util/include
-)
-target_link_libraries(clmTypeCheck
-    clmUtil
 )

--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -11,7 +11,7 @@ list(APPEND CLM_UTIL_SOURCES
     src/clm_type.c
 )
 
-add_library(clmUtil STATIC ${CLM_UTIL_SOURCES})
+add_library(clmUtil OBJECT ${CLM_UTIL_SOURCES})
 target_include_directories(clmUtil
     PUBLIC include
 )


### PR DESCRIPTION
Previously when building, was building each directory as a static library and linking each to it's dependencies... now each is build as an object library and then they are all linked together into clm.exe. So now no libraries are produced as a result of compilation.
